### PR TITLE
Ignore items where the checkbox is part of the strike-through

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -32871,7 +32871,7 @@ function hasCheckedItem(line, checklistItem) {
 }
 
 function hasInactiveItem(line, checklistItem) {
-  return line.includes(`~${checklistItem}~`);
+  return line.includes(`~${checklistItem}~`) || line.includes(`~[ ] ${checklistItem}~`);
 }
 
 run();


### PR DESCRIPTION
I edit checklist items by striking out the whole line (after the bullet), so the checkbox is also part of the strike-through.

It took me several tries before reading the source code for this action to I understand that I must only strike through the words, not the box.